### PR TITLE
Add Score and Payment structs

### DIFF
--- a/src/fu.rs
+++ b/src/fu.rs
@@ -1,3 +1,5 @@
+use crate::score::FuValue;
+
 #[derive(Debug, PartialEq)]
 pub enum Fu {
     BasePoints,
@@ -39,7 +41,7 @@ impl std::fmt::Display for Fu {
 
 impl Fu {
     /// Get the minipoint value.
-    pub fn value(&self) -> u16 {
+    pub fn value(&self) -> FuValue {
         match self {
             Self::BasePoints => 20,
             Self::BasePointsChitoi => 25,
@@ -60,8 +62,8 @@ impl Fu {
 }
 
 /// Sum up all of the fu, rounding to the nearest 10.
-pub fn calculate_total_fu_value(fu: &[Fu]) -> u16 {
-    ((fu.iter().map(|f| f.value()).sum::<u16>() + 9) / 10) * 10
+pub fn calculate_total_fu_value(fu: &[Fu]) -> FuValue {
+    ((fu.iter().map(|f| f.value()).sum::<FuValue>() + 9) / 10) * 10
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod calc;
 pub mod fu;
 pub mod hand;
 pub mod limit_hand;
+pub mod score;
 pub mod suit;
 pub mod tile_group;
 pub mod yaku;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod calc;
 pub mod fu;
 pub mod hand;
 pub mod limit_hand;
+pub mod payment;
 pub mod score;
 pub mod suit;
 pub mod tile_group;

--- a/src/limit_hand.rs
+++ b/src/limit_hand.rs
@@ -1,3 +1,9 @@
+use crate::score::{
+    FuValue, HanValue, Payment, DEALER_RON_MULTIPLIER, DEALER_TSUMO_MULTIPLIER,
+    NON_DEALER_RON_MULTIPLIER, NON_DEALER_TSUMO_TO_DEALER_MULTIPLIER,
+    NON_DEALER_TSUMO_TO_NON_DEALER_MULTIPLIER,
+};
+
 #[derive(Debug)]
 pub enum LimitHands {
     Mangan,
@@ -10,7 +16,7 @@ pub enum LimitHands {
 impl LimitHands {
     //TODO: MOVE THIS INTO A SUITABLE STRUCT LATER
     /// Check if the score of the hand is limited (no aotenjou).
-    fn is_limit_hand(han: u16, fu: u16) -> bool {
+    fn is_limit_hand(han: HanValue, fu: FuValue) -> bool {
         if han >= 5 {
             return true;
         }
@@ -27,7 +33,7 @@ impl LimitHands {
     }
 
     /// Calculate the limit hand type from the han and fu scores.
-    pub fn get_limit_hand(han: u16, fu: u16) -> Option<Self> {
+    pub fn get_limit_hand(han: HanValue, fu: FuValue) -> Option<Self> {
         if !Self::is_limit_hand(han, fu) {
             return None;
         }
@@ -47,52 +53,21 @@ impl LimitHands {
     }
 
     /// Get the payment amounts.
-    ///
-    /// Format is as follows:
-    ///
-    /// - dealer_ron
-    /// - dealer_tsumo
-    /// - non_dealer_ron
-    /// - non_dealer_tsumo_to_non_dealer
-    /// - non_dealer_tsumo_to_dealer
-    pub fn get_score(&self) -> Vec<u16> {
-        match self {
-            Self::Mangan => {
-                vec![12000, 4000, 8000, 2000, 4000]
-            }
-            Self::Haneman => {
-                let vec = Self::Mangan.get_score();
-                let mut out: Vec<u16> = Vec::new();
-                for i in vec {
-                    let j = i / 2;
-                    out.push(i + j)
-                }
-                out
-            }
-            Self::Baiman => {
-                let vec = Self::Mangan.get_score();
-                let mut out: Vec<u16> = Vec::new();
-                for i in vec {
-                    out.push(i * 2)
-                }
-                out
-            }
-            Self::Sanbaiman => {
-                let vec = Self::Mangan.get_score();
-                let mut out: Vec<u16> = Vec::new();
-                for i in vec {
-                    out.push(i * 3)
-                }
-                out
-            }
-            Self::KazoeYakuman => {
-                let vec = Self::Mangan.get_score();
-                let mut out: Vec<u16> = Vec::new();
-                for i in vec {
-                    out.push(i * 4)
-                }
-                out
-            }
-        }
+    pub fn get_score(&self) -> Payment {
+        let base_points = match self {
+            Self::Mangan => 2_000,
+            Self::Haneman => 3_000,
+            Self::Baiman => 4_000,
+            Self::Sanbaiman => 6_000,
+            Self::KazoeYakuman => 8_000,
+        };
+
+        Payment::new(
+            base_points * DEALER_RON_MULTIPLIER,
+            base_points * DEALER_TSUMO_MULTIPLIER,
+            base_points * NON_DEALER_RON_MULTIPLIER,
+            base_points * NON_DEALER_TSUMO_TO_NON_DEALER_MULTIPLIER,
+            base_points * NON_DEALER_TSUMO_TO_DEALER_MULTIPLIER,
+        )
     }
 }

--- a/src/limit_hand.rs
+++ b/src/limit_hand.rs
@@ -1,8 +1,5 @@
-use crate::score::{
-    FuValue, HanValue, Payment, DEALER_RON_MULTIPLIER, DEALER_TSUMO_MULTIPLIER,
-    NON_DEALER_RON_MULTIPLIER, NON_DEALER_TSUMO_TO_DEALER_MULTIPLIER,
-    NON_DEALER_TSUMO_TO_NON_DEALER_MULTIPLIER,
-};
+use crate::payment::Payment;
+use crate::score::{FuValue, HanValue};
 
 #[derive(Debug)]
 pub enum LimitHands {
@@ -62,12 +59,6 @@ impl LimitHands {
             Self::KazoeYakuman => 8_000,
         };
 
-        Payment::new(
-            base_points * DEALER_RON_MULTIPLIER,
-            base_points * DEALER_TSUMO_MULTIPLIER,
-            base_points * NON_DEALER_RON_MULTIPLIER,
-            base_points * NON_DEALER_TSUMO_TO_NON_DEALER_MULTIPLIER,
-            base_points * NON_DEALER_TSUMO_TO_DEALER_MULTIPLIER,
-        )
+        Payment::new(base_points)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,13 +249,15 @@ pub fn default_hand_out(
     out
 }
 pub fn parse_file(args: &Args) {
-    let string = fs::read_to_string(args.file.as_ref().unwrap());
-    if string.is_err() {
-        eprintln!("Error: Unable to read file {}", args.file.as_ref().unwrap());
-        return;
-    }
-    let string = string.unwrap();
-    let lines = string.lines();
+    let file_contents = match fs::read_to_string(args.file.as_ref().unwrap()) {
+        Ok(contents) => contents,
+        Err(_) => {
+            eprintln!("Error: Unable to read file {}", args.file.as_ref().unwrap());
+            return;
+        }
+    };
+
+    let lines = file_contents.lines();
     for string in lines {
         if string.is_empty() {
             continue;

--- a/src/payment.rs
+++ b/src/payment.rs
@@ -1,0 +1,178 @@
+use crate::score::{FuValue, HanValue, HonbaCounter};
+
+/// Number of points players pay to the winner.
+// NOTE: `u64` allows for scoring with aotenjou (no limits).
+pub(crate) type Points = u64;
+
+const DEALER_RON_MULTIPLIER: u64 = 6;
+const DEALER_TSUMO_MULTIPLIER: u64 = 2;
+const NON_DEALER_RON_MULTIPLIER: u64 = 4;
+const NON_DEALER_TSUMO_TO_NON_DEALER_MULTIPLIER: u64 = 1;
+const NON_DEALER_TSUMO_TO_DEALER_MULTIPLIER: u64 = 2;
+
+/// Methods to provide a breakdown of payment amounts players will pay.
+///
+/// This struct stores the base points the hand was awarded.
+///
+/// # Base value forumla
+///
+/// The formula for calculating the base value without caps or limits applied (aotenjou)
+/// or han < 5 (no aotenjou) is:
+///
+/// ```text
+/// fu * 2 ^ (2 + han)
+/// ```
+///
+/// # Limit Scores Base Points
+///
+/// These are the base points for han >= 5.
+///
+/// | Limit Name | Han   | Base Points |
+/// |:----------:|:-----:|:-----------:|
+/// | Mangan     | 5     | 2,000       |
+/// | Haneman    | 6-7   | 3,000       |
+/// | Baiman     | 8-10  | 4,000       |
+/// | Sanbaiman  | 11-12 | 6,000       |
+/// | Yakuman    | 13+   | 8,000       |
+///
+/// # Payment
+///
+/// Multiply the basic point value by the amount listed in the table below.
+///
+/// |                | Tsumo                                           | Ron                           |
+/// |----------------|-------------------------------------------------|-------------------------------|
+/// | **Non-dealer** | - 1x by other non-dealers<br>- 2x by the dealer | - 4x by the discarding player |
+/// | **Dealer**     | - 2x from all other players                     | - 6x by the discarding player |
+///
+/// Each payment is rounded up to the nearest 100.
+///
+/// In addition to the payment, the winner is paid an additional amount of points based on the number of honba counters on the table.
+///
+/// # Examples
+///
+/// < 5 han
+///
+/// ```rust
+/// use mahc::payment::Payment;
+///
+/// let han = 2;
+/// let fu = 40;
+/// let payment = Payment::from_han_and_fu(han, fu);
+/// let expected_base_points = 640;
+/// assert_eq!(payment.base_points(), expected_base_points);
+///
+/// let honba = 0;
+/// let expected_payment_ron = 2_600;
+/// assert_eq!(payment.non_dealer_ron(honba), expected_payment_ron);
+/// ```
+///
+/// Mangan:
+///
+/// ```rust
+/// use mahc::payment::Payment;
+///
+/// let base_points_mangan = 2_000;
+/// let payment = Payment::new(base_points_mangan);
+///
+/// let honba = 0;
+/// let expected_dealer_ron = 12_000;
+/// assert_eq!(payment.dealer_ron(honba), expected_dealer_ron);
+///
+/// let honba = 2;
+/// let expected_dealer_tsumo = 4_200;
+/// assert_eq!(payment.dealer_tsumo(honba), expected_dealer_tsumo);
+/// ```
+#[derive(Debug)]
+pub struct Payment {
+    /// Base score for the hand.
+    base_points: Points,
+    /// The number of points each honba (repeat counter) is worth.
+    tsumibou: Points,
+}
+
+impl Payment {
+    /// Create a new [`Payment`].
+    pub fn new(base_points: Points) -> Self {
+        Self {
+            base_points,
+            tsumibou: 300,
+        }
+    }
+
+    /// Calculate the base points with the given han and fu.
+    ///
+    /// <div class="warning">
+    ///
+    /// This will not factor in any limitations (assumes aotenjou).
+    ///
+    /// </div>
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use mahc::payment::Payment;
+    ///
+    /// let han = 1;
+    /// let fu = 32;
+    /// let payment = Payment::from_han_and_fu(han, fu);
+    /// let expected_base_value = 320;
+    /// assert_eq!(payment.base_points(), expected_base_value);
+    /// ```
+    pub fn from_han_and_fu(han: HanValue, fu: FuValue) -> Self {
+        let fu = if fu == 25 {
+            // Chiitoitsu (seven pairs) does not round the fu.
+            fu
+        } else {
+            // Round up to the nearest 10.
+            (fu + 9) / 10 * 10
+        };
+
+        Self::new(fu * 2u64.pow(han + 2))
+    }
+
+    /// Get the base points.
+    pub fn base_points(&self) -> Points {
+        self.base_points
+    }
+
+    /// Round the payment amount to the nearest hundredth.
+    fn round_payment(&self, unrounded_payment: Points) -> Points {
+        (unrounded_payment + 99) / 100 * 100
+    }
+
+    /// Get the amount of points the player that dealt-in has to pay to a dealer.
+    pub fn dealer_ron(&self, honba: HonbaCounter) -> Points {
+        self.round_payment((self.base_points * DEALER_RON_MULTIPLIER) + (self.tsumibou * honba))
+    }
+
+    /// Get the amount of points each player pays when the dealer tsumos.
+    pub fn dealer_tsumo(&self, honba: HonbaCounter) -> Points {
+        // NOTE: This is assuming a 4-player game where the tsumibou is divided by the number of other players.
+        self.round_payment(
+            (self.base_points * DEALER_TSUMO_MULTIPLIER) + ((self.tsumibou / 3) * honba),
+        )
+    }
+
+    /// Get the amount the player that dealt-in pays to a non-dealer.
+    pub fn non_dealer_ron(&self, honba: HonbaCounter) -> Points {
+        self.round_payment((self.base_points * NON_DEALER_RON_MULTIPLIER) + (self.tsumibou * honba))
+    }
+
+    /// Get the amount the dealer pays when a non-dealer wins by tsumo.
+    pub fn non_dealer_tsumo_to_dealer(&self, honba: HonbaCounter) -> Points {
+        // NOTE: This is assuming a 4-player game where the tsumibou is divided by the number of other players.
+        self.round_payment(
+            (self.base_points * NON_DEALER_TSUMO_TO_DEALER_MULTIPLIER)
+                + ((self.tsumibou / 3) * honba),
+        )
+    }
+
+    /// Get the amount non-dealer players pay when a non-dealer wins by tsumo.
+    pub fn non_dealer_tsumo_to_non_dealer(&self, honba: HonbaCounter) -> Points {
+        // NOTE: This is assuming a 4-player game where the tsumibou is divided by the number of other players.
+        self.round_payment(
+            (self.base_points * NON_DEALER_TSUMO_TO_NON_DEALER_MULTIPLIER)
+                + ((self.tsumibou / 3) * honba),
+        )
+    }
+}

--- a/src/score.rs
+++ b/src/score.rs
@@ -1,21 +1,13 @@
 use crate::fu::Fu;
+use crate::payment::Payment;
 use crate::yaku::Yaku;
 
-/// Number of points players pay to the winner.
-// NOTE: `u64` allows for scoring with aotenjou (no limits).
-pub type Points = u64;
 /// Han value.
 pub type HanValue = u32;
 /// Fu (minipoints) value.
 pub type FuValue = u64;
 /// Number of honba (repeat counts).
 pub type HonbaCounter = u64;
-
-pub(crate) const DEALER_RON_MULTIPLIER: u64 = 6;
-pub(crate) const DEALER_TSUMO_MULTIPLIER: u64 = 2;
-pub(crate) const NON_DEALER_RON_MULTIPLIER: u64 = 4;
-pub(crate) const NON_DEALER_TSUMO_TO_NON_DEALER_MULTIPLIER: u64 = 1;
-pub(crate) const NON_DEALER_TSUMO_TO_DEALER_MULTIPLIER: u64 = 2;
 
 /// Detailed breakdown of the winning hand's score.
 #[derive(Debug)]
@@ -30,6 +22,8 @@ pub struct Score {
     han: HanValue,
     /// Total score of the fu that were awarded.
     fu_score: FuValue,
+    /// Number of repeat counters.
+    honba: HonbaCounter,
     /// Is the hand open when it scored?
     is_open: bool,
 }
@@ -42,6 +36,7 @@ impl Score {
         fu: Vec<Fu>,
         han: HanValue,
         fu_score: FuValue,
+        honba: HonbaCounter,
         is_open: bool,
     ) -> Self {
         Self {
@@ -50,6 +45,7 @@ impl Score {
             fu,
             han,
             fu_score,
+            honba,
             is_open,
         }
     }
@@ -79,92 +75,13 @@ impl Score {
         self.fu_score
     }
 
+    /// Get the number of repeat counters.
+    pub fn honba(&self) -> HonbaCounter {
+        self.honba
+    }
+
     /// Get the state of whether or not the hand was opened.
     pub fn is_open(&self) -> bool {
         self.is_open
-    }
-}
-
-/// Breakdown of payment amounts players will pay.
-#[derive(Debug)]
-pub struct Payment {
-    /// The amount the player that dealt-in pays to the dealer.
-    dealer_ron: Points,
-    /// The amount each player pays when the dealer tsumos.
-    dealer_tsumo: Points,
-    /// The amount the player that dealt-in pays to a non-dealer.
-    non_dealer_ron: Points,
-    /// The amount non-dealer players pay when a non-dealer wins by tsumo.
-    non_dealer_tsumo_to_non_dealer: Points,
-    /// The amount the dealer pays when a non-dealer wins by tsumo.
-    non_dealer_tsumo_to_dealer: Points,
-}
-
-impl Payment {
-    /// Create a new [`Payment`].
-    pub fn new(
-        dealer_ron: Points,
-        dealer_tsumo: Points,
-        non_dealer_ron: Points,
-        non_dealer_tsumo_to_non_dealer: Points,
-        non_dealer_tsumo_to_dealer: Points,
-    ) -> Self {
-        Self {
-            dealer_ron,
-            dealer_tsumo,
-            non_dealer_ron,
-            non_dealer_tsumo_to_non_dealer,
-            non_dealer_tsumo_to_dealer,
-        }
-    }
-
-    /// Get the amount of points the player that dealt-in has to pay to a dealer.
-    pub fn dealer_ron(&self) -> Points {
-        self.dealer_ron
-    }
-
-    /// Set the amount of points the player that dealt-in has to pay to a dealer.
-    pub fn set_dealer_ron(&mut self, dealer_ron: Points) {
-        self.dealer_ron = dealer_ron;
-    }
-
-    /// Get the amount of points each player pays when the dealer tsumos.
-    pub fn dealer_tsumo(&self) -> Points {
-        self.dealer_tsumo
-    }
-
-    /// Set the amount of points each player pays when the dealer tsumos.
-    pub fn set_dealer_tsumo(&mut self, dealer_tsumo: Points) {
-        self.dealer_tsumo = dealer_tsumo;
-    }
-
-    /// Get the amount the player that dealt-in pays to a non-dealer.
-    pub fn non_dealer_ron(&self) -> Points {
-        self.non_dealer_ron
-    }
-
-    /// Set the amount the player that dealt-in pays to a non-dealer.
-    pub fn set_non_dealer_ron(&mut self, non_dealer_ron: Points) {
-        self.non_dealer_ron = non_dealer_ron;
-    }
-
-    /// Get the amount non-dealer players pay when a non-dealer wins by tsumo.
-    pub fn non_dealer_tsumo_to_non_dealer(&self) -> Points {
-        self.non_dealer_tsumo_to_non_dealer
-    }
-
-    /// Set the amount non-dealer players pay when a non-dealer wins by tsumo.
-    pub fn set_non_dealer_tsumo_to_non_dealer(&mut self, non_dealer_tsumo_to_non_dealer: Points) {
-        self.non_dealer_tsumo_to_non_dealer = non_dealer_tsumo_to_non_dealer;
-    }
-
-    /// Get the amount the dealer pays when a non-dealer wins by tsumo.
-    pub fn non_dealer_tsumo_to_dealer(&self) -> Points {
-        self.non_dealer_tsumo_to_dealer
-    }
-
-    /// Set the amount the dealer pays when a non-dealer wins by tsumo.
-    pub fn set_non_dealer_tsumo_to_dealer(&mut self, non_dealer_tsumo_to_dealer: Points) {
-        self.non_dealer_tsumo_to_dealer = non_dealer_tsumo_to_dealer;
     }
 }

--- a/src/score.rs
+++ b/src/score.rs
@@ -1,0 +1,170 @@
+use crate::fu::Fu;
+use crate::yaku::Yaku;
+
+/// Number of points players pay to the winner.
+// NOTE: `u64` allows for scoring with aotenjou (no limits).
+pub type Points = u64;
+/// Han value.
+pub type HanValue = u32;
+/// Fu (minipoints) value.
+pub type FuValue = u64;
+/// Number of honba (repeat counts).
+pub type HonbaCounter = u64;
+
+pub(crate) const DEALER_RON_MULTIPLIER: u64 = 6;
+pub(crate) const DEALER_TSUMO_MULTIPLIER: u64 = 2;
+pub(crate) const NON_DEALER_RON_MULTIPLIER: u64 = 4;
+pub(crate) const NON_DEALER_TSUMO_TO_NON_DEALER_MULTIPLIER: u64 = 1;
+pub(crate) const NON_DEALER_TSUMO_TO_DEALER_MULTIPLIER: u64 = 2;
+
+/// Detailed breakdown of the winning hand's score.
+#[derive(Debug)]
+pub struct Score {
+    /// Breakdown of payment amounts.
+    payment: Payment,
+    /// List of yaku that were awarded.
+    yaku: Vec<Yaku>,
+    /// List of fu that were awarded.
+    fu: Vec<Fu>,
+    /// Total score of the yaku that were awarded including dora.
+    han: HanValue,
+    /// Total score of the fu that were awarded.
+    fu_score: FuValue,
+    /// Is the hand open when it scored?
+    is_open: bool,
+}
+
+impl Score {
+    /// Create a new [`Score`].
+    pub fn new(
+        payment: Payment,
+        yaku: Vec<Yaku>,
+        fu: Vec<Fu>,
+        han: HanValue,
+        fu_score: FuValue,
+        is_open: bool,
+    ) -> Self {
+        Self {
+            payment,
+            yaku,
+            fu,
+            han,
+            fu_score,
+            is_open,
+        }
+    }
+
+    /// Get the payment breakdown.
+    pub fn payment(&self) -> &Payment {
+        &self.payment
+    }
+
+    /// Get the list of yaku that were awarded.
+    pub fn yaku(&self) -> &[Yaku] {
+        &self.yaku
+    }
+
+    /// Get the list of fu that were awarded.
+    pub fn fu(&self) -> &[Fu] {
+        &self.fu
+    }
+
+    /// Get the total han value of the hand.
+    pub fn han(&self) -> HanValue {
+        self.han
+    }
+
+    /// Get the total fu (minipoints) value of the hand.
+    pub fn fu_score(&self) -> FuValue {
+        self.fu_score
+    }
+
+    /// Get the state of whether or not the hand was opened.
+    pub fn is_open(&self) -> bool {
+        self.is_open
+    }
+}
+
+/// Breakdown of payment amounts players will pay.
+#[derive(Debug)]
+pub struct Payment {
+    /// The amount the player that dealt-in pays to the dealer.
+    dealer_ron: Points,
+    /// The amount each player pays when the dealer tsumos.
+    dealer_tsumo: Points,
+    /// The amount the player that dealt-in pays to a non-dealer.
+    non_dealer_ron: Points,
+    /// The amount non-dealer players pay when a non-dealer wins by tsumo.
+    non_dealer_tsumo_to_non_dealer: Points,
+    /// The amount the dealer pays when a non-dealer wins by tsumo.
+    non_dealer_tsumo_to_dealer: Points,
+}
+
+impl Payment {
+    /// Create a new [`Payment`].
+    pub fn new(
+        dealer_ron: Points,
+        dealer_tsumo: Points,
+        non_dealer_ron: Points,
+        non_dealer_tsumo_to_non_dealer: Points,
+        non_dealer_tsumo_to_dealer: Points,
+    ) -> Self {
+        Self {
+            dealer_ron,
+            dealer_tsumo,
+            non_dealer_ron,
+            non_dealer_tsumo_to_non_dealer,
+            non_dealer_tsumo_to_dealer,
+        }
+    }
+
+    /// Get the amount of points the player that dealt-in has to pay to a dealer.
+    pub fn dealer_ron(&self) -> Points {
+        self.dealer_ron
+    }
+
+    /// Set the amount of points the player that dealt-in has to pay to a dealer.
+    pub fn set_dealer_ron(&mut self, dealer_ron: Points) {
+        self.dealer_ron = dealer_ron;
+    }
+
+    /// Get the amount of points each player pays when the dealer tsumos.
+    pub fn dealer_tsumo(&self) -> Points {
+        self.dealer_tsumo
+    }
+
+    /// Set the amount of points each player pays when the dealer tsumos.
+    pub fn set_dealer_tsumo(&mut self, dealer_tsumo: Points) {
+        self.dealer_tsumo = dealer_tsumo;
+    }
+
+    /// Get the amount the player that dealt-in pays to a non-dealer.
+    pub fn non_dealer_ron(&self) -> Points {
+        self.non_dealer_ron
+    }
+
+    /// Set the amount the player that dealt-in pays to a non-dealer.
+    pub fn set_non_dealer_ron(&mut self, non_dealer_ron: Points) {
+        self.non_dealer_ron = non_dealer_ron;
+    }
+
+    /// Get the amount non-dealer players pay when a non-dealer wins by tsumo.
+    pub fn non_dealer_tsumo_to_non_dealer(&self) -> Points {
+        self.non_dealer_tsumo_to_non_dealer
+    }
+
+    /// Set the amount non-dealer players pay when a non-dealer wins by tsumo.
+    pub fn set_non_dealer_tsumo_to_non_dealer(&mut self, non_dealer_tsumo_to_non_dealer: Points) {
+        self.non_dealer_tsumo_to_non_dealer = non_dealer_tsumo_to_non_dealer;
+    }
+
+    /// Get the amount the dealer pays when a non-dealer wins by tsumo.
+    pub fn non_dealer_tsumo_to_dealer(&self) -> Points {
+        self.non_dealer_tsumo_to_dealer
+    }
+
+    /// Set the amount the dealer pays when a non-dealer wins by tsumo.
+    pub fn set_non_dealer_tsumo_to_dealer(&mut self, non_dealer_tsumo_to_dealer: Points) {
+        self.non_dealer_tsumo_to_dealer = non_dealer_tsumo_to_dealer;
+    }
+}

--- a/src/yaku.rs
+++ b/src/yaku.rs
@@ -1,3 +1,5 @@
+use crate::score::HanValue;
+
 #[derive(Debug, PartialEq)]
 pub enum Yaku {
     // One Han Yaku
@@ -146,7 +148,7 @@ impl Yaku {
 
     //TODO adjust for open or closed !!!!
     /// Get the han value of the yaku.
-    pub fn get_han(&self, is_open: bool) -> u16 {
+    pub fn get_han(&self, is_open: bool) -> HanValue {
         match self {
             Self::Tanyao
             | Self::Iipeikou


### PR DESCRIPTION
This replaces the arbitrary `Vec<u16>`, which had an assumption of a
fixed number of elements. With a struct, the fields are known and makes
it easier to add, remove, or modify types.

The reason for why the new structs have private fields and public access methods is to make them future-proof (See [Rust API Guidelines: Structs have private fields](https://rust-lang.github.io/api-guidelines/future-proofing.html#structs-have-private-fields-c-struct-private)).

The new Payment struct centralizes where the payment calculation occurs in the code and simplifies the code in the places that had previously calculated it when determining the score.

---

Many of the function parameters could probably be converted to use generics to allow for greater flexibility.

One example could be (psudo-code with [`Into<T>`](https://doc.rust-lang.org/std/convert/trait.Into.html#examples)):

```diff
- pub fn calculate(han: u32, fu: u64, honba: HonbaCounter) -> Result<Payment, HandErr> {
+ pub fn calculate(han: Into<u32>, fu: Into<u64>, honba: HonbaCounter) -> Result<Payment, HandErr> {
+     let han = han.into();
+     let fu = fu.into();
```

For example, this would allow a caller to pass in a `u16` for `han` and the function (specifically the `.into()` calls) would just handle it with no problem.

---

Test results:

![image](https://github.com/user-attachments/assets/3e84c750-cb2e-4dfd-a769-fb518845bcb7)

