### PR TITLE
Add RoundContext struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod fu;
 pub mod hand;
 pub mod limit_hand;
 pub mod payment;
+pub mod round_context;
 pub mod score;
 pub mod suit;
 pub mod tile_group;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 use mahc::calc;
 use mahc::hand::error::HandErr;
 use mahc::payment::Payment;
+use mahc::round_context::{Riichi, RoundContext};
 use mahc::score::{FuValue, HanValue, HonbaCounter, Score};
 use serde_json::json;
 
@@ -122,20 +123,36 @@ pub fn parse_hand(args: &Args) -> Result<String, HandErr> {
     if args.doubleriichi && args.haitei && args.chankan {
         return Err(HandErr::DoubleRiichiHaiteiChankan);
     }
+
+    let round_context = {
+        let riichi = if args.riichi || args.doubleriichi {
+            if args.riichi {
+                Some(Riichi::Riichi)
+            } else {
+                Some(Riichi::DoubleRiichi)
+            }
+        } else {
+            None
+        };
+
+        RoundContext::builder()
+            .tsumo(args.tsumo)
+            .riichi(riichi)
+            .ippatsu(args.ippatsu)
+            .rinshan(args.rinshan)
+            .chankan(args.chankan)
+            .haitei(args.haitei)
+            .tenhou(args.tenhou)
+            .build()
+    };
+
     let score = calc::get_hand_score(
         args.tiles.clone().unwrap(),
         args.win.clone().unwrap(),
         args.dora,
         args.seat.clone(),
         args.prev.clone(),
-        args.tsumo,
-        args.riichi,
-        args.doubleriichi,
-        args.ippatsu,
-        args.haitei,
-        args.rinshan,
-        args.chankan,
-        args.tenhou,
+        &round_context,
         args.ba,
     )?;
 

--- a/src/round_context.rs
+++ b/src/round_context.rs
@@ -1,0 +1,200 @@
+/// Variations of declaring riichi.
+#[derive(Debug, PartialEq)]
+pub enum Riichi {
+    /// Declared a ready closed hand.
+    Riichi,
+    /// Called riichi on the first turn.
+    DoubleRiichi,
+}
+
+#[derive(Debug, Default)]
+pub struct RoundContext {
+    /// Winning off of a self-draw with a closed hand.
+    tsumo: bool,
+
+    /// Declared a ready closed hand.
+    riichi: Option<Riichi>,
+    /// Winning on the next uninterrupted draw after declaring riichi.
+    ippatsu: bool,
+
+    /// Winning with the replacement tile after calling kan.
+    rinshan: bool,
+    /// Robbing a kan.
+    chankan: bool,
+
+    /// Winning from the starting hand.
+    haitei: bool,
+    /// Winning as the dealer with the haitei (initial draw).
+    tenhou: bool,
+}
+
+impl RoundContext {
+    /// Create a new [`RoundContext`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        tsumo: bool,
+        riichi: Option<Riichi>,
+        ippatsu: bool,
+        rinshan: bool,
+        chankan: bool,
+        haitei: bool,
+        tenhou: bool,
+    ) -> Self {
+        Self {
+            tsumo,
+            riichi,
+            ippatsu,
+            rinshan,
+            chankan,
+            haitei,
+            tenhou,
+        }
+    }
+
+    /// Create a new `RoundContext` builder.
+    pub fn builder() -> RoundContextBuilder {
+        RoundContextBuilder::default()
+    }
+
+    /// Get the tsumo state.
+    pub fn tsumo(&self) -> bool {
+        self.tsumo
+    }
+
+    /// Get the riichi status.
+    pub fn riichi(&self) -> &Option<Riichi> {
+        &self.riichi
+    }
+
+    /// Get the ippatsu state.
+    pub fn ippatsu(&self) -> bool {
+        self.ippatsu
+    }
+
+    /// Get the rinshan kaihou status.
+    pub fn rinshan(&self) -> bool {
+        self.rinshan
+    }
+
+    /// Get the chankan status.
+    pub fn chankan(&self) -> bool {
+        self.chankan
+    }
+
+    /// Get the state of whether or not it is the haitei (initial draw).
+    pub fn haitei(&self) -> bool {
+        self.haitei
+    }
+
+    /// Did the dealer win on the haitei (initial draw)?
+    pub fn tenhou(&self) -> bool {
+        self.tenhou
+    }
+}
+
+/// Builder to create a [`RoundContext`].
+///
+/// # Examples
+///
+/// ```rust
+/// use mahc::round_context::{Riichi, RoundContext};
+///
+/// let round_context = RoundContext::builder()
+///     .tsumo(true)
+///     .riichi(Some(Riichi::Riichi))
+///     .ippatsu(true)
+///     .build();
+///
+/// assert!(round_context.tsumo());
+/// let expected_riichi = Some(Riichi::Riichi);
+/// assert_eq!(round_context.riichi(), &expected_riichi);
+/// assert!(round_context.ippatsu());
+/// assert!(!round_context.rinshan());
+/// assert!(!round_context.chankan());
+/// assert!(!round_context.haitei());
+/// assert!(!round_context.tenhou());
+/// ```
+#[derive(Debug, Default)]
+pub struct RoundContextBuilder {
+    /// Winning off of a self-draw with a closed hand.
+    tsumo: bool,
+
+    /// Declared a ready closed hand.
+    riichi: Option<Riichi>,
+    /// Winning on the next uninterrupted draw after declaring riichi.
+    ippatsu: bool,
+
+    /// Winning with the replacement tile after calling kan.
+    rinshan: bool,
+    /// Robbing a kan.
+    chankan: bool,
+
+    /// Winning from the starting hand.
+    haitei: bool,
+    /// Winning as the dealer with the haitei (initial draw).
+    tenhou: bool,
+}
+
+impl RoundContextBuilder {
+    /// Create a [`RoundContext`] from this builder struct.
+    pub fn build(self) -> RoundContext {
+        RoundContext::new(
+            self.tsumo,
+            self.riichi,
+            self.ippatsu,
+            self.rinshan,
+            self.chankan,
+            self.haitei,
+            self.tenhou,
+        )
+    }
+
+    /// Set the `tsumo` value.
+    pub fn tsumo(mut self, tsumo: bool) -> Self {
+        self.tsumo = tsumo;
+
+        self
+    }
+
+    /// Set the `riichi` value.
+    pub fn riichi(mut self, riichi: Option<Riichi>) -> Self {
+        self.riichi = riichi;
+
+        self
+    }
+
+    /// Set the `ippatsu` value.
+    pub fn ippatsu(mut self, ippatsu: bool) -> Self {
+        self.ippatsu = ippatsu;
+
+        self
+    }
+
+    /// Set the `rinshan` value.
+    pub fn rinshan(mut self, rinshan: bool) -> Self {
+        self.rinshan = rinshan;
+
+        self
+    }
+
+    /// Set the `chankan` value.
+    pub fn chankan(mut self, chankan: bool) -> Self {
+        self.chankan = chankan;
+
+        self
+    }
+
+    /// Set the `haitei` value.
+    pub fn haitei(mut self, haitei: bool) -> Self {
+        self.haitei = haitei;
+
+        self
+    }
+
+    /// Set the `tenhou` value.
+    pub fn tenhou(mut self, tenhou: bool) -> Self {
+        self.tenhou = tenhou;
+
+        self
+    }
+}


### PR DESCRIPTION
This is a change that I'm not 100% sold on because of the use of the builder pattern. Overall, I'd consider this change non-essential and I leave it at your discretion to include this or not.

---

This struct contains some context around the round to determine if some yaku should be awarded such as riichi. Having this struct reduces the number of arguments in `get_hand_score()` and `get_yaku_han()` while also keeping the data and types between them consistent.

Using the builder pattern introduces a lot of duplicated code and requires that the builder struct (`RoundContextBuilder`) stays in sync with the main struct (`RoundContext`). This can be alleviated by creating a proc macro but macros often obfuscate code, IDEs struggle with making correct suggestions when they're used, and they often slow down compilation time.