### PR TITLE
4 add support for mpsz notation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.5.2"
 edition = "2021"
 authors =[  "Tharun <tharun1@hotmail.co.uk>" ]
 description = "cli riichi mahjong calculator, which spits out yaku and fu for a given hand"
-repository = "https://github.com/DrCheeseFace/rusty-mahjcalc"
+repository = "https://github.com/DrCheeseFace/mahc"
 license = "MIT"
 readme = "README.md"
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ CLI tool that calculates the score of a hand in riichi mahjong. <br>
 ### Normal Mode
 note: the winning group has to go last (this is to calculate fu correctly)
 ``` bash
-~/$ mahc --tiles rrrd EEEw 234p 234p 11p -w 1p -p Ew -s Ew
+~/$ mahc --tiles 777z 111z 234p 234p 11p -w 1p -p Ew -s Ew
 > 7 Han/ 50 Fu
   Dealer: 18000 (6000)
   Non-dealer: 12000 (3000/6000)
@@ -116,27 +116,29 @@ yields
 
 ### Suits
 
-| Suit  | Tiles                                      |
-|-------|--------------------------------------------|
+| Type  | Notation                                      |
+|-------|-----------------------------------------------|
 | Man (Characters) | 1m, 2m, 3m, 4m, 5m, 6m, 7m, 8m, 9m |
 | Pin (Circles)    | 1p, 2p, 3p, 4p, 5p, 6p, 7p, 8p, 9p |
 | Sou (Bamboos)    | 1s, 2s, 3s, 4s, 5s, 6s, 7s, 8s, 9s |
 
 ### Honors
 
-| Type  | Notation          |
-|-------|-------------------|
-| Winds | Ew, Sw, Ww, Nw    |
-| Dragons | rd, gd, wd      |
+| Type    | Notation       | MPSZ Notation      |
+|---------|----------------|--------------------|
+| Winds   | Ew, Sw, Ww, Nw |1z, 2z, 3z, 4z      |
+| Dragons | wd, gd, rd     |5z, 6z, 7z          |
 
 ### Special Notation
 
-| Description     | Example           |
-|-----------------|-------------------|
+| Description     | Example                                         |
+|-----------------|-------------------------------------------------|
 | Open Sets       | 234po (an open sequence of 2, 3, 4 in Pin suit) |
+| akadora         | 0m, 0p, 0s                                      | 
 
 - eg: EEEw (triplet of east wind)
 - eg: 234m (sequence of 2 3 4 Man)
+- eg: 406s (sequence of 4 5 6 Sou with the akadora 5 sou)
 - eg: rrrrdo (open quad of red dragon)
 - eg: 11s (pair of 1 sou)
 - eg: 8m (8 man tile)
@@ -163,7 +165,7 @@ cd mahc/x86_64-unknown-linux-gnu/release
 ./mahc --version
 ```
 
-### Implemented hand validations as of yet
+## Implemented hand validations as of yet
 
 ##### One Han Yaku
 - [x] Tanyao

--- a/src/fu.rs
+++ b/src/fu.rs
@@ -82,7 +82,7 @@ mod tests {
                 "789m".to_string(),
             ],
             "7m".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -112,7 +112,7 @@ mod tests {
                 "789m".to_string(),
             ],
             "7m".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -141,7 +141,7 @@ mod tests {
                 "456s".to_string(),
             ],
             "6s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();

--- a/src/hand.rs
+++ b/src/hand.rs
@@ -55,9 +55,26 @@ impl Hand {
         }
 
         // AHAHAHAHAHAHAHAHAh (these are special cases for singular tiles)
+        let value = win.chars().nth(0).unwrap().to_string();
+        let suitchar = &win.chars().nth(1).unwrap().to_string();
+        let suit = Suit::suit_from_string(&suitchar, &value)?;
+        let value = if suitchar == "z" {
+            match value.as_str() {
+                "1" => "E".to_string(),
+                "2" => "S".to_string(),
+                "3" => "W".to_string(),
+                "4" => "N".to_string(),
+                "5" => "w".to_string(),
+                "6" => "g".to_string(),
+                "7" => "r".to_string(),
+                _ => value,
+            }
+        } else {
+            value
+        };
         let win_tile = TileGroup {
-            value: win.chars().nth(0).unwrap().to_string(),
-            suit: Suit::suit_from_string(win.chars().nth(1).unwrap().to_string())?,
+            value: value.clone(),
+            suit,
             isopen: false,
             group_type: GroupType::None,
             isterminal: TERMINAL_CHARS.contains(&win.chars().nth(0).unwrap()),
@@ -89,17 +106,52 @@ impl Hand {
             }
         }
 
+        let value = seat.chars().nth(0).unwrap().to_string();
+        let suitchar = &seat.chars().nth(1).unwrap().to_string();
+        let suit = Suit::suit_from_string(&suitchar, &value)?;
+        let value = if suitchar == "z" {
+            match value.as_str() {
+                "1" => "E".to_string(),
+                "2" => "S".to_string(),
+                "3" => "W".to_string(),
+                "4" => "N".to_string(),
+                "5" => "w".to_string(),
+                "6" => "g".to_string(),
+                "7" => "r".to_string(),
+                _ => value,
+            }
+        } else {
+            value
+        };
         let seat_tile = TileGroup {
-            value: seat.chars().nth(0).unwrap().to_string(),
-            suit: Suit::suit_from_string(seat.chars().nth(1).unwrap().to_string())?,
+            value: value.clone(),
+            suit, 
             isopen: false,
             group_type: GroupType::None,
             isterminal: TERMINAL_CHARS.contains(&seat.chars().nth(0).unwrap()),
         };
 
+        let value = prev.chars().nth(0).unwrap().to_string();
+        let suitchar = &prev.chars().nth(1).unwrap().to_string();
+        let suit = Suit::suit_from_string(&suitchar, &value)?;
+        let value = if suitchar == "z" {
+            match value.as_str() {
+                "1" => "E".to_string(),
+                "2" => "S".to_string(),
+                "3" => "W".to_string(),
+                "4" => "N".to_string(),
+                "5" => "w".to_string(),
+                "6" => "g".to_string(),
+                "7" => "r".to_string(),
+                _ => value,
+            }
+        } else {
+            value
+        };
+
         let prev_tile = TileGroup {
-            value: prev.chars().nth(0).unwrap().to_string(),
-            suit: Suit::suit_from_string(prev.chars().nth(1).unwrap().to_string())?,
+            value: value.clone(),
+            suit, 
             isopen: false,
             group_type: GroupType::None,
             isterminal: TERMINAL_CHARS.contains(&prev.chars().nth(0).unwrap()),
@@ -920,7 +972,7 @@ mod tests {
         let out = Hand::new(
             vec![
                 "1s".to_string(),
-                "1s".to_string(),
+                "2s".to_string(),
                 "1m".to_string(),
                 "9m".to_string(),
                 "1p".to_string(),
@@ -2189,7 +2241,7 @@ mod tests {
                 "rrrd".to_string(),
             ],
             "rd".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();

--- a/src/hand.rs
+++ b/src/hand.rs
@@ -891,7 +891,7 @@ mod tests {
                 "wwd".to_string(),
             ],
             "wd".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -913,7 +913,7 @@ mod tests {
                 "wwd".to_string(),
             ],
             "wd".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -935,7 +935,7 @@ mod tests {
                 "wwd".to_string(),
             ],
             "wd".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -958,7 +958,7 @@ mod tests {
                 "rd".to_string(),
             ],
             "rd".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -981,7 +981,7 @@ mod tests {
                 "wwd".to_string(),
             ],
             "wd".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -999,7 +999,7 @@ mod tests {
                 "99s".to_string(),
             ],
             "9s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1013,7 +1013,7 @@ mod tests {
                 "999s".to_string(),
             ],
             "9s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1031,7 +1031,7 @@ mod tests {
                 "999s".to_string(),
             ],
             "9s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1045,7 +1045,7 @@ mod tests {
                 "999s".to_string(),
             ],
             "9s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1063,7 +1063,7 @@ mod tests {
                 "99s".to_string(),
             ],
             "9s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1077,7 +1077,7 @@ mod tests {
                 "99s".to_string(),
             ],
             "9s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1097,7 +1097,7 @@ mod tests {
                 "EEw".to_string(),
             ],
             "Ew".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1111,7 +1111,7 @@ mod tests {
                 "EEEw".to_string(),
             ],
             "Ew".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1129,7 +1129,7 @@ mod tests {
                 "EEEw".to_string(),
             ],
             "Ew".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1143,7 +1143,7 @@ mod tests {
                 "EEEw".to_string(),
             ],
             "Ew".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1161,7 +1161,7 @@ mod tests {
                 "999s".to_string(),
             ],
             "9s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1175,7 +1175,7 @@ mod tests {
                 "999s".to_string(),
             ],
             "9s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1189,7 +1189,7 @@ mod tests {
                 "99s".to_string(),
             ],
             "9s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1203,7 +1203,7 @@ mod tests {
                 "55s".to_string(),
             ],
             "5s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1217,7 +1217,7 @@ mod tests {
                 "999s".to_string(),
             ],
             "9s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1235,7 +1235,7 @@ mod tests {
                 "888s".to_string(),
             ],
             "8s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1249,7 +1249,7 @@ mod tests {
                 "888s".to_string(),
             ],
             "8s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1263,7 +1263,7 @@ mod tests {
                 "888s".to_string(),
             ],
             "8s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1278,7 +1278,7 @@ mod tests {
                 "99s".to_string(),
             ],
             "9s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1296,7 +1296,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1310,7 +1310,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1324,7 +1324,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1342,7 +1342,7 @@ mod tests {
                 "11m".to_string(),
             ],
             "1m".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1356,7 +1356,7 @@ mod tests {
                 "111s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1374,7 +1374,7 @@ mod tests {
                 "11m".to_string(),
             ],
             "1m".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1389,7 +1389,7 @@ mod tests {
                 "111s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1403,7 +1403,7 @@ mod tests {
                 "111s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1421,7 +1421,7 @@ mod tests {
                 "567p".to_string(),
             ],
             "6p".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1435,7 +1435,7 @@ mod tests {
                 "567p".to_string(),
             ],
             "6p".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1450,7 +1450,7 @@ mod tests {
                 "567p".to_string(),
             ],
             "6p".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1468,7 +1468,7 @@ mod tests {
                 "567p".to_string(),
             ],
             "6p".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1482,7 +1482,7 @@ mod tests {
                 "567p".to_string(),
             ],
             "6p".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1500,7 +1500,7 @@ mod tests {
                 "456m".to_string(),
             ],
             "6m".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1514,7 +1514,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1528,7 +1528,7 @@ mod tests {
                 "333s".to_string(),
             ],
             "3s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1546,7 +1546,7 @@ mod tests {
                 "456m".to_string(),
             ],
             "6m".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1561,7 +1561,7 @@ mod tests {
                 "456m".to_string(),
             ],
             "5m".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1575,7 +1575,7 @@ mod tests {
                 "456m".to_string(),
             ],
             "5m".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1589,7 +1589,7 @@ mod tests {
                 "rrrd".to_string(),
             ],
             "rd".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1609,7 +1609,7 @@ mod tests {
                 "77p".to_string(),
             ],
             "7p".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1626,7 +1626,7 @@ mod tests {
                 "77p".to_string(),
             ],
             "7p".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1641,7 +1641,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1661,7 +1661,7 @@ mod tests {
                 "77p".to_string(),
             ],
             "7p".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1675,7 +1675,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1693,7 +1693,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1708,7 +1708,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1722,7 +1722,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1740,7 +1740,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1755,7 +1755,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1769,7 +1769,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1783,7 +1783,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1801,7 +1801,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1815,7 +1815,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1833,7 +1833,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1848,7 +1848,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1863,7 +1863,7 @@ mod tests {
                 "99p".to_string(),
             ],
             "9p".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1881,7 +1881,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1896,7 +1896,7 @@ mod tests {
                 "ggd".to_string(),
             ],
             "gd".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1911,7 +1911,7 @@ mod tests {
                 "11p".to_string(),
             ],
             "1p".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1929,7 +1929,7 @@ mod tests {
                 "gggd".to_string(),
             ],
             "gd".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1943,7 +1943,7 @@ mod tests {
                 "234p".to_string(),
             ],
             "4p".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1961,7 +1961,7 @@ mod tests {
                 "gggd".to_string(),
             ],
             "gd".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1976,7 +1976,7 @@ mod tests {
                 "gggd".to_string(),
             ],
             "gd".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -1991,7 +1991,7 @@ mod tests {
                 "33p".to_string(),
             ],
             "3p".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -2010,7 +2010,7 @@ mod tests {
                 "333p".to_string(),
             ],
             "3p".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -2025,7 +2025,7 @@ mod tests {
                 "333p".to_string(),
             ],
             "3p".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -2040,7 +2040,7 @@ mod tests {
                 "333p".to_string(),
             ],
             "3p".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -2058,7 +2058,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -2073,7 +2073,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -2088,7 +2088,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -2106,7 +2106,7 @@ mod tests {
                 "11s".to_string(),
             ],
             "1s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -2121,7 +2121,7 @@ mod tests {
                 "gggd".to_string(),
             ],
             "gd".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -2136,7 +2136,7 @@ mod tests {
                 "456so".to_string(),
             ],
             "5s".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -2154,7 +2154,7 @@ mod tests {
                 "678m".to_string(),
             ],
             "7m".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -2176,13 +2176,13 @@ mod tests {
         let out = Hand::new(
             vec![
                 "3333mo".to_string(),
-                "WWWm".to_string(),
+                "WWWw".to_string(),
                 "22s".to_string(),
                 "234m".to_string(),
                 "678m".to_string(),
             ],
             "7m".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -2196,7 +2196,7 @@ mod tests {
                 "678m".to_string(),
             ],
             "7m".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -2214,7 +2214,7 @@ mod tests {
                 "77m".to_string(),
             ],
             "7m".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -2230,7 +2230,7 @@ mod tests {
                 "77m".to_string(),
             ],
             "7m".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -2249,7 +2249,7 @@ mod tests {
                 "77m".to_string(),
             ],
             "7m".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -2265,7 +2265,7 @@ mod tests {
                 "678m".to_string(),
             ],
             "7m".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -2281,7 +2281,7 @@ mod tests {
                 "678m".to_string(),
             ],
             "7m".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -2299,7 +2299,7 @@ mod tests {
                 "678m".to_string(),
             ],
             "7m".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -2313,7 +2313,7 @@ mod tests {
                 "678m".to_string(),
             ],
             "7m".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();
@@ -2327,7 +2327,7 @@ mod tests {
                 "345m".to_string(),
             ],
             "4m".to_string(),
-            "Es".to_string(),
+            "Ew".to_string(),
             "Ww".to_string(),
         )
         .unwrap();

--- a/src/hand.rs
+++ b/src/hand.rs
@@ -3,7 +3,6 @@ pub mod error;
 use crate::fu::Fu;
 use crate::suit::Suit;
 use crate::tile_group::{GroupType, TileGroup};
-use crate::TERMINAL_CHARS;
 use error::HandErr;
 
 #[derive(Debug)]
@@ -28,7 +27,7 @@ impl Hand {
 
         // NOTE: Strings are complicated in Rust and needs evaluation about how to iterate over one. Because the string is expected to contain ASCII characters, `.chars()` should be okay.
         for i in &tiles {
-            let tile = TileGroup::new(i.to_string())?;
+            let tile: TileGroup = i.to_string().try_into()?;
             if tile.isopen {
                 ishandopen = true;
             }
@@ -55,30 +54,7 @@ impl Hand {
         }
 
         // AHAHAHAHAHAHAHAHAh (these are special cases for singular tiles)
-        let value = win.chars().nth(0).unwrap().to_string();
-        let suitchar = &win.chars().nth(1).unwrap().to_string();
-        let suit = Suit::suit_from_string(&suitchar, &value)?;
-        let value = if suitchar == "z" {
-            match value.as_str() {
-                "1" => "E".to_string(),
-                "2" => "S".to_string(),
-                "3" => "W".to_string(),
-                "4" => "N".to_string(),
-                "5" => "w".to_string(),
-                "6" => "g".to_string(),
-                "7" => "r".to_string(),
-                _ => value,
-            }
-        } else {
-            value
-        };
-        let win_tile = TileGroup {
-            value: value.clone(),
-            suit,
-            isopen: false,
-            group_type: GroupType::None,
-            isterminal: TERMINAL_CHARS.contains(&win.chars().nth(0).unwrap()),
-        };
+        let win_tile: TileGroup = win.try_into()?;
 
         // check if last group contains the winning tile
         // FUCK handling kokuushi
@@ -105,57 +81,8 @@ impl Hand {
                 GroupType::Kan | GroupType::None => return Err(HandErr::InvalidShape),
             }
         }
-
-        let value = seat.chars().nth(0).unwrap().to_string();
-        let suitchar = &seat.chars().nth(1).unwrap().to_string();
-        let suit = Suit::suit_from_string(&suitchar, &value)?;
-        let value = if suitchar == "z" {
-            match value.as_str() {
-                "1" => "E".to_string(),
-                "2" => "S".to_string(),
-                "3" => "W".to_string(),
-                "4" => "N".to_string(),
-                "5" => "w".to_string(),
-                "6" => "g".to_string(),
-                "7" => "r".to_string(),
-                _ => value,
-            }
-        } else {
-            value
-        };
-        let seat_tile = TileGroup {
-            value: value.clone(),
-            suit, 
-            isopen: false,
-            group_type: GroupType::None,
-            isterminal: TERMINAL_CHARS.contains(&seat.chars().nth(0).unwrap()),
-        };
-
-        let value = prev.chars().nth(0).unwrap().to_string();
-        let suitchar = &prev.chars().nth(1).unwrap().to_string();
-        let suit = Suit::suit_from_string(&suitchar, &value)?;
-        let value = if suitchar == "z" {
-            match value.as_str() {
-                "1" => "E".to_string(),
-                "2" => "S".to_string(),
-                "3" => "W".to_string(),
-                "4" => "N".to_string(),
-                "5" => "w".to_string(),
-                "6" => "g".to_string(),
-                "7" => "r".to_string(),
-                _ => value,
-            }
-        } else {
-            value
-        };
-
-        let prev_tile = TileGroup {
-            value: value.clone(),
-            suit, 
-            isopen: false,
-            group_type: GroupType::None,
-            isterminal: TERMINAL_CHARS.contains(&prev.chars().nth(0).unwrap()),
-        };
+        let seat_tile: TileGroup = seat.try_into()?;
+        let prev_tile: TileGroup = prev.try_into()?;
 
         let hand = Self {
             groups: tile_groups,
@@ -2287,8 +2214,8 @@ mod tests {
                 "77m".to_string(),
             ],
             "7m".to_string(),
-            "es".to_string(),
-            "ww".to_string(),
+            "Es".to_string(),
+            "Ww".to_string(),
         )
         .unwrap();
         //is open
@@ -2303,8 +2230,8 @@ mod tests {
                 "77m".to_string(),
             ],
             "7m".to_string(),
-            "es".to_string(),
-            "ww".to_string(),
+            "Es".to_string(),
+            "Ww".to_string(),
         )
         .unwrap();
         //is open

--- a/src/suit.rs
+++ b/src/suit.rs
@@ -30,12 +30,29 @@ impl Suit {
     /// assert_eq!(actual_suit, expected);
     /// ```
     pub fn suit_from_string(suit: &String, value: &String) -> Result<Self, HandErr> {
-       match suit.as_str() {
+        if vec!["s", "p", "m"].contains(&suit.as_str())
+            && !vec!["1", "2", "3", "4", "5", "6", "7", "8", "9"].contains(&value.as_str())
+        {
+            return Err(HandErr::InvalidGroup);
+        }
+        match suit.as_str() {
             "s" => Ok(Self::Souzu),
             "p" => Ok(Self::Pinzu),
             "m" => Ok(Self::Manzu),
-            "w" => Ok(Self::Wind),
-            "d" => Ok(Self::Dragon),
+            "w" => {
+                if !vec!["E", "S", "W", "N"].contains(&value.as_str()) {
+                    Err(HandErr::InvalidGroup)
+                } else {
+                    Ok(Self::Wind)
+                }
+            }
+            "d" => {
+                if !vec!["r", "g", "w"].contains(&value.as_str()) {
+                    Err(HandErr::InvalidGroup)
+                } else {
+                    Ok(Self::Dragon)
+                }
+            }
             "z" => {
                 if vec!["1", "2", "3", "4"].contains(&value.as_str()) {
                     Ok(Self::Wind)

--- a/src/suit.rs
+++ b/src/suit.rs
@@ -42,7 +42,7 @@ impl Suit {
                 } else if vec!["5", "6", "7"].contains(&value.as_str()) {
                     Ok(Self::Dragon)
                 } else {
-                    Err(HandErr::InvalidSuit)
+                    Err(HandErr::InvalidGroup)
                 }
             }
             _ => Err(HandErr::InvalidSuit),

--- a/src/suit.rs
+++ b/src/suit.rs
@@ -120,4 +120,19 @@ mod test {
 
         assert_eq!(actual, expected);
     }
+    #[test]
+    fn akadora_suit_from_string() {
+        let value = "0".to_string();
+        let suit = "m".to_string();
+        let actual = Suit::suit_from_string(&suit, &value);
+        let expected = Ok(Suit::Manzu);
+        assert_eq!(actual, expected);
+
+        let value = "0".to_string();
+        let suit = "z".to_string();
+        let actual = Suit::suit_from_string(&suit, &value);
+        let expected = Err(HandErr::InvalidGroup); 
+        assert_eq!(actual, expected);
+
+    }
 }

--- a/src/suit.rs
+++ b/src/suit.rs
@@ -18,19 +18,89 @@ impl Suit {
     /// use mahc::suit::Suit;
     ///
     /// let tile_string = "9m";
-    /// let actual_suit = Suit::suit_from_string(tile_string.chars().nth(1).unwrap().to_string());
+    /// let actual_suit = Suit::suit_from_string(&tile_string.chars().nth(1).unwrap().to_string(), &tile_string.chars().nth(0).unwrap().to_string());
     /// let expected = Ok(Suit::Manzu);
     ///
     /// assert_eq!(actual_suit, expected);
+    ///
+    /// let tile_string = "6z";
+    /// let actual_suit = Suit::suit_from_string(&tile_string.chars().nth(1).unwrap().to_string(), &tile_string.chars().nth(0).unwrap().to_string());
+    /// let expected = Ok(Suit::Dragon);
+    ///
+    /// assert_eq!(actual_suit, expected);
     /// ```
-    pub fn suit_from_string(suit: String) -> Result<Self, HandErr> {
-        match suit.as_str() {
+    pub fn suit_from_string(suit: &String, value: &String) -> Result<Self, HandErr> {
+       match suit.as_str() {
             "s" => Ok(Self::Souzu),
             "p" => Ok(Self::Pinzu),
             "m" => Ok(Self::Manzu),
             "w" => Ok(Self::Wind),
             "d" => Ok(Self::Dragon),
+            "z" => {
+                if vec!["1", "2", "3", "4"].contains(&value.as_str()) {
+                    Ok(Self::Wind)
+                } else if vec!["5", "6", "7"].contains(&value.as_str()) {
+                    Ok(Self::Dragon)
+                } else {
+                    Err(HandErr::InvalidSuit)
+                }
+            }
             _ => Err(HandErr::InvalidSuit),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn souzu_suit_from_string() {
+        let suit = "s".to_string();
+        let value = "1".to_string();
+        let actual = Suit::suit_from_string(&suit, &value);
+        let expected = Ok(Suit::Souzu);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn manzu_suit_from_string() {
+        let suit = "m".to_string();
+        let value = "1".to_string();
+        let actual = Suit::suit_from_string(&suit, &value);
+        let expected = Ok(Suit::Manzu);
+
+        assert_eq!(actual, expected);
+    }
+    #[test]
+    fn pinzu_suit_from_string() {
+        let suit = "p".to_string();
+        let value = "1".to_string();
+        let actual = Suit::suit_from_string(&suit, &value);
+        let expected = Ok(Suit::Pinzu);
+
+        assert_eq!(actual, expected);
+    }
+    #[test]
+    fn wind_suit_from_string() {
+        let suit = "z".to_string();
+        let value = "1".to_string();
+        let actual = Suit::suit_from_string(&suit, &value);
+        let expected = Ok(Suit::Wind);
+
+        assert_eq!(actual, expected);
+        let suit = "z".to_string();
+        let value = "4".to_string();
+        let actual = Suit::suit_from_string(&suit, &value);
+        let expected = Ok(Suit::Wind);
+
+        assert_eq!(actual, expected);
+        let suit = "w".to_string();
+        let value = "W".to_string();
+        let actual = Suit::suit_from_string(&suit, &value);
+        let expected = Ok(Suit::Wind);
+
+        assert_eq!(actual, expected);
     }
 }

--- a/src/suit.rs
+++ b/src/suit.rs
@@ -31,7 +31,7 @@ impl Suit {
     /// ```
     pub fn suit_from_string(suit: &String, value: &String) -> Result<Self, HandErr> {
         if vec!["s", "p", "m"].contains(&suit.as_str())
-            && !vec!["1", "2", "3", "4", "5", "6", "7", "8", "9"].contains(&value.as_str())
+            && !vec!["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"].contains(&value.as_str())
         {
             return Err(HandErr::InvalidGroup);
         }

--- a/src/tile_group.rs
+++ b/src/tile_group.rs
@@ -8,6 +8,7 @@ pub struct TileGroup {
     pub isopen: bool,
     pub group_type: GroupType,
     pub isterminal: bool,
+    pub isaka: bool,
 }
 impl TryFrom<String> for TileGroup {
     type Error = HandErr;
@@ -19,7 +20,17 @@ impl TryFrom<String> for TileGroup {
 impl TileGroup {
     fn new(group: String) -> Result<Self, HandErr> {
         let isopen = group.chars().last().unwrap().to_string() == "o";
-        let value = group.chars().nth(0).unwrap().to_string();
+
+        // is akadora check (sussy bcuz not every tile needs an akadora attribute)
+        let mut isaka = false;
+        let value = if group.chars().nth(0).unwrap().to_string() == "0" {
+            "5".to_string()
+        } else {
+            group.chars().nth(0).unwrap().to_string()
+        };
+        if group.contains("0") {
+            isaka = true;
+        }
 
         let suitchar = if !isopen {
             group.chars().last().unwrap().to_string()
@@ -59,6 +70,7 @@ impl TileGroup {
             isopen,
             group_type,
             isterminal,
+            isaka,
         };
 
         Ok(tile)
@@ -100,12 +112,13 @@ impl GroupType {
     ///
     /// assert_eq!(actual, expected);
     /// ```
-    pub fn group_type_from_string(group: String) -> Result<Self, HandErr> {
+    pub fn group_type_from_string(mut group: String) -> Result<Self, HandErr> {
         let count = if group.contains('o') {
             group.len() - 2
         } else {
             group.len() - 1
         };
+        group = group.replace("0", "5");
 
         if let Some(sub_group) = group.get(0..count) {
             for i in sub_group.chars() {

--- a/src/tile_group.rs
+++ b/src/tile_group.rs
@@ -249,4 +249,30 @@ mod tests {
         let tile = TileGroup::try_from("999z".to_string());
         assert_eq!(tile, Err(HandErr::InvalidGroup));
     }
+
+    #[test]
+    fn is_akadora_from_string() {
+        let tile = TileGroup::try_from("0m".to_string()).unwrap();
+        assert_eq!(tile.value, "5");
+        assert_eq!(tile.isaka, true);
+        assert_eq!(tile.group_type, GroupType::None);
+
+        let tile = TileGroup::try_from("055m".to_string()).unwrap();
+        assert_eq!(tile.value, "5");
+        assert_eq!(tile.isaka, true);
+        assert_eq!(tile.group_type, GroupType::Triplet);
+
+        let tile = TileGroup::try_from("406m".to_string()).unwrap();
+        assert_eq!(tile.value, "4");
+        assert_eq!(tile.isaka, true);
+        assert_eq!(tile.group_type, GroupType::Sequence);
+    }
+
+    #[test]
+    fn is_not_akadora_from_string() {
+        let tile = TileGroup::try_from("1m".to_string()).unwrap();
+        assert_eq!(tile.value, "1");
+        assert_eq!(tile.isaka, false);
+        assert_eq!(tile.group_type, GroupType::None);
+    }
 }

--- a/src/tile_group.rs
+++ b/src/tile_group.rs
@@ -15,12 +15,26 @@ impl TileGroup {
         let isopen = group.chars().last().unwrap().to_string() == "o";
         let value = group.chars().nth(0).unwrap().to_string();
 
-        let suit = if !isopen {
+        let suitchar = if !isopen {
             group.chars().last().unwrap().to_string()
         } else {
             group.chars().nth(group.len() - 2).unwrap().to_string()
         };
-        let suit = Suit::suit_from_string(suit)?;
+        let suit = Suit::suit_from_string(&suitchar, &value)?;
+        let value = if suitchar == "z" {
+            match value.as_str() {
+                "1" => "E".to_string(),
+                "2" => "S".to_string(),
+                "3" => "W".to_string(),
+                "4" => "N".to_string(),
+                "5" => "w".to_string(),
+                "6" => "g".to_string(),
+                "7" => "r".to_string(),
+                _ => value,
+            }
+        } else {
+            value
+        };
 
         let group_type = GroupType::group_type_from_string(group.to_string())?;
 
@@ -29,7 +43,7 @@ impl TileGroup {
             if value == "1" || value == "7" {
                 isterminal = true;
             }
-        } else if value == "1" || value == "9" {
+        } else if (value == "1" || value == "9") && suit != Suit::Wind && suit != Suit::Dragon {
             isterminal = true;
         }
 

--- a/src/tile_group.rs
+++ b/src/tile_group.rs
@@ -40,8 +40,6 @@ impl TileGroup {
             }
         } else {
             value
-            
-            
         };
 
         let group_type = GroupType::group_type_from_string(group.to_string())?;
@@ -141,5 +139,101 @@ impl GroupType {
             1 => Ok(Self::None),
             _ => Err(HandErr::InvalidGroup),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_honor_tilegroup_from_string() {
+        let tile = TileGroup::try_from("1m".to_string()).unwrap();
+        assert_eq!(tile.suit, Suit::Manzu);
+        assert_eq!(tile.value, "1");
+        assert!(!tile.isopen);
+        assert_eq!(tile.group_type, GroupType::None);
+        assert!(tile.isterminal);
+
+        let tile = TileGroup::try_from("111mo".to_string()).unwrap();
+        assert!(tile.isopen);
+        assert_eq!(tile.group_type, GroupType::Triplet);
+        assert_eq!(tile.suit, Suit::Manzu);
+
+        let tile = TileGroup::try_from("123m".to_string()).unwrap();
+        assert_eq!(tile.group_type, GroupType::Sequence);
+        assert_eq!(tile.suit, Suit::Manzu);
+
+        let tile = TileGroup::try_from("234m".to_string()).unwrap();
+        assert_eq!(tile.group_type, GroupType::Sequence);
+        assert_eq!(tile.suit, Suit::Manzu);
+        assert!(!tile.isterminal);
+    }
+
+    #[test]
+    fn wind_tilegroup_from_string() {
+        let tile = TileGroup::try_from("1z".to_string()).unwrap();
+        assert_eq!(tile.suit, Suit::Wind);
+        assert_eq!(tile.value, "E");
+        assert!(!tile.isopen);
+        assert_eq!(tile.group_type, GroupType::None);
+        assert_eq!(tile.isterminal, false);
+
+        let tile = TileGroup::try_from("222zo".to_string()).unwrap();
+        assert!(tile.isopen);
+        assert_eq!(tile.group_type, GroupType::Triplet);
+        assert_eq!(tile.suit, Suit::Wind);
+        assert_eq!(tile.value, "S");
+
+        let tile = TileGroup::try_from("EEEEw".to_string()).unwrap();
+        assert!(!tile.isopen);
+        assert_eq!(tile.group_type, GroupType::Kan);
+        assert_eq!(tile.suit, Suit::Wind);
+        assert_eq!(tile.value, "E");
+    }
+
+    #[test]
+    fn dragon_tilegroup_from_string() {
+        let tile = TileGroup::try_from("5z".to_string()).unwrap();
+        assert_eq!(tile.suit, Suit::Dragon);
+        assert_eq!(tile.value, "w");
+        assert!(!tile.isopen);
+        assert_eq!(tile.group_type, GroupType::None);
+
+        let tile = TileGroup::try_from("666zo".to_string()).unwrap();
+        assert_eq!(tile.suit, Suit::Dragon);
+        assert_eq!(tile.value, "g");
+        assert!(tile.isopen);
+        assert_eq!(tile.group_type, GroupType::Triplet);
+
+        let tile = TileGroup::try_from("7777z".to_string()).unwrap();
+        assert!(!tile.isopen);
+        assert_eq!(tile.group_type, GroupType::Kan);
+        assert_eq!(tile.suit, Suit::Dragon);
+        assert_eq!(tile.value, "r");
+    }
+
+    #[test]
+    fn no_suit_error_from_string() {
+        let tile = TileGroup::try_from("1".to_string());
+        assert_eq!(tile, Err(HandErr::InvalidSuit));
+    }
+
+    #[test]
+    fn no_value_error_from_string() {
+        let tile = TileGroup::try_from("m".to_string());
+        assert_eq!(tile, Err(HandErr::InvalidGroup));
+    }
+
+    #[test]
+    fn too_large_error_from_string() {
+        let tile = TileGroup::try_from("11111s".to_string());
+        assert_eq!(tile, Err(HandErr::InvalidGroup));
+    }
+
+    #[test]
+    fn invalid_suit_error_from_string() {
+        let tile = TileGroup::try_from("999z".to_string());
+        assert_eq!(tile, Err(HandErr::InvalidGroup));
     }
 }

--- a/src/tile_group.rs
+++ b/src/tile_group.rs
@@ -12,13 +12,7 @@ pub struct TileGroup {
 }
 impl TryFrom<String> for TileGroup {
     type Error = HandErr;
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        TileGroup::new(value.to_string())
-    }
-}
-
-impl TileGroup {
-    fn new(group: String) -> Result<Self, HandErr> {
+    fn try_from(group: String) -> Result<Self, Self::Error> {
         let isopen = group.chars().last().unwrap().to_string() == "o";
 
         // is akadora check (sussy bcuz not every tile needs an akadora attribute)
@@ -64,6 +58,19 @@ impl TileGroup {
             isterminal = true;
         }
 
+        TileGroup::new(value, suit, isopen, group_type, isterminal, isaka)
+    }
+}
+
+impl TileGroup {
+    fn new(
+        value: String,
+        suit: Suit,
+        isopen: bool,
+        group_type: GroupType,
+        isterminal: bool,
+        isaka: bool,
+    ) -> Result<Self, HandErr> {
         let tile = Self {
             value,
             suit,

--- a/src/tile_group.rs
+++ b/src/tile_group.rs
@@ -9,9 +9,15 @@ pub struct TileGroup {
     pub group_type: GroupType,
     pub isterminal: bool,
 }
+impl TryFrom<String> for TileGroup {
+    type Error = HandErr;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        TileGroup::new(value.to_string())
+    }
+}
 
 impl TileGroup {
-    pub fn new(group: String) -> Result<Self, HandErr> {
+    fn new(group: String) -> Result<Self, HandErr> {
         let isopen = group.chars().last().unwrap().to_string() == "o";
         let value = group.chars().nth(0).unwrap().to_string();
 
@@ -34,6 +40,8 @@ impl TileGroup {
             }
         } else {
             value
+            
+            
         };
 
         let group_type = GroupType::group_type_from_string(group.to_string())?;


### PR DESCRIPTION
![carbon (3)](https://github.com/user-attachments/assets/4aed16a6-55a3-4179-8a6c-6bbdd04c5402)
- should be able to handle tile input such as ```111z```  ```555z``` (honor tile groups)
- bunch of validation and test cases for handling ```akadora``` tile groups eg: ```406m```
- ```TryFrom<String>``` trait added to ```TileGroup``` 
```rust 
impl TryFrom<String> for TileGroup {
    type Error = HandErr;
    fn try_from(value: String) -> Result<Self, Self::Error> {
       .
       .
       .
        TileGroup::new(value, suit, isopen, group_type, isterminal, isaka)
    }
}
```
- ```isaka``` attribute added to ```TileGroup``` 
```rust 
pub struct TileGroup {
    pub value: String,
    pub suit: Suit,
    pub isopen: bool,
    pub group_type: GroupType,
    pub isterminal: bool,
    pub isaka: bool,
}
```
- ```TileGroup::new(group: String) -> Result<Self, HandErr>``` signature changed to    
```rust 
TileGroup::new(
        value: String,
        suit: Suit,
        isopen: bool,
        group_type: GroupType,
        isterminal: bool,
        isaka: bool,
    ) -> Result<Self, HandErr> 
```

- not the biggest fan of this solution since every tile group, including those that dont contain a 5's have an ```isaka``` attribute now
-  but its better than having to handle ```0``` as the value of a tile group everywhere
