### PR TITLE
Fix chuurenpoutou9sided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 this.txt
 in.txt
+mahc.txt

--- a/src/hand.rs
+++ b/src/hand.rs
@@ -1384,6 +1384,7 @@ mod tests {
 
     #[test]
     fn yaku_chuurenpoutou() {
+        // Valid chuuren
         let out = Hand::new_from_strings(
             vec![
                 "111s".to_string(),
@@ -1398,6 +1399,8 @@ mod tests {
         )
         .unwrap();
         assert!(out.is_chuurenpoutou());
+
+        // Invalid: mixed suits
         let out = Hand::new_from_strings(
             vec![
                 "111s".to_string(),
@@ -1412,6 +1415,8 @@ mod tests {
         )
         .unwrap();
         assert!(!out.is_chuurenpoutou());
+
+        // Invalid: wrong tile pattern
         let out = Hand::new_from_strings(
             vec![
                 "123s".to_string(),
@@ -1426,6 +1431,8 @@ mod tests {
         )
         .unwrap();
         assert!(!out.is_chuurenpoutou());
+
+        // 9-sided wait: extra=5, win=5 (true 9-sided)
         let out = Hand::new_from_strings(
             vec![
                 "111s".to_string(),
@@ -1440,6 +1447,8 @@ mod tests {
         )
         .unwrap();
         assert!(out.is_chuurenpoutou9sided());
+
+        // NOT 9-sided: extra=5, win=9
         let out = Hand::new_from_strings(
             vec![
                 "111s".to_string(),
@@ -1454,7 +1463,8 @@ mod tests {
         )
         .unwrap();
         assert!(!out.is_chuurenpoutou9sided());
-        // Extra 1: 123p 456p 789p 999p 11p
+
+        // NOT 9-sided: extra=9, win=1
         let out = Hand::new_from_strings(
             vec![
                 "123p".to_string(),
@@ -1469,7 +1479,9 @@ mod tests {
         )
         .unwrap();
         assert!(out.is_chuurenpoutou());
-        // Extra 9: 111p 123p 456p 789p 99p
+        assert!(!out.is_chuurenpoutou9sided());
+
+        // NOT 9-sided: extra=1, win=9
         let out = Hand::new_from_strings(
             vec![
                 "111p".to_string(),
@@ -1484,6 +1496,7 @@ mod tests {
         )
         .unwrap();
         assert!(out.is_chuurenpoutou());
+        assert!(!out.is_chuurenpoutou9sided());
     }
 
     #[test]

--- a/src/hand.rs
+++ b/src/hand.rs
@@ -860,19 +860,39 @@ impl Hand {
     ///
     /// This variant checks that the hand was completed with a 9-sided wait.
     pub fn is_chuurenpoutou9sided(&self) -> bool {
-        if self.groups.len() == 13 {
-            return false;
-        }
-
         if !self.is_chuurenpoutou() {
             return false;
         }
 
-        if self.groups.last().unwrap().group_type() != GroupType::Pair {
-            return false;
+        // Count tiles and find which position has the extra
+        let mut counts = [0u8; 10];
+        for group in &self.groups {
+            let v = group.value().to_string().parse::<usize>().unwrap();
+            match group.group_type() {
+                GroupType::Triplet => counts[v] += 3,
+                GroupType::Sequence => {
+                    counts[v] += 1;
+                    counts[v + 1] += 1;
+                    counts[v + 2] += 1;
+                }
+                GroupType::Pair => counts[v] += 2,
+                GroupType::Kan => counts[v] += 4,
+                GroupType::None => return false,
+            }
         }
 
-        true
+        let base: [u8; 10] = [0, 3, 1, 1, 1, 1, 1, 1, 1, 3];
+
+        // Find which value has the extra tile
+        for i in 1..=9 {
+            if counts[i] == base[i] + 1 {
+                // For 9-sided wait, winning tile must be the extra
+                let win_val = self.win_tile.value().to_digit(10).unwrap() as usize;
+                return win_val == i;
+            }
+        }
+
+        false
     }
 
     /// Check if the hand only consists of honor tiles.


### PR DESCRIPTION
The old implementation only checked if the last group was a pair, which doesn't determine a 9-sided wait.

A true 9-sided wait (Junsei Chuuren Poutou) requires the tenpai hand to be exactly `1112345678999`, meaning the winning tile is the "extra" tile that completes the hand.

### Example

```bash
# True 9-sided wait — tenpai was 1112345678999, won on 5p (the extra)
mahc --tiles 111p 234p 678p 999p 55p -w 5p -p Ew -s Ew
# -> Double yakuman ✓

# NOT 9-sided — tenpai was 1123456789999, won on 1p (extra was 9)
mahc --tiles 123p 456p 789p 999p 11p -w 1p -p Ew -s Ew
# -> Single yakuman ✓ (was incorrectly double yakuman before)
```

Closes #36 